### PR TITLE
Add path to bf-swithch SAI headers

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -42,7 +42,7 @@ CFLAGS_COMMON="-std=c++11 -Wall -fPIC -Wno-write-strings -I/usr/include/libnl3 -
 
 AM_CONDITIONAL(sonic_asic_platform_barefoot,   test x$CONFIGURED_PLATFORM = xbarefoot)
 AM_COND_IF([sonic_asic_platform_barefoot],
-           [CFLAGS_COMMON+=" -I/opt/bfn/install/include/switchsai"])
+           [CFLAGS_COMMON+=" -I/opt/bfn/install/include/switchsai -I/opt/bfn/install/include/bf_switch/sai/"])
 
 CFLAGS_COMMON+=" -Werror"
 CFLAGS_COMMON+=" -Wno-reorder"


### PR DESCRIPTION
Signed-off-by: Nadiya.Stetskovych <nstetskovych@barefootnetworks.com>
**What I did**
Add the path to SAI headers used by bf-switch
**How I verified it**
Verify compilation


